### PR TITLE
Add default value support for attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Add `default` option for attribute definitions.
+
 ## [0.1.4]
 
 - Add skip serializing attribute feature.


### PR DESCRIPTION
This commit adds support for default values in attribute definitions. When an attribute is not present in the deserialized data, the default value will be used instead.

Features:
- Type validation for default values at class definition time
- Support for default values with 'only' constraint
- Proper handling during deserialization

Example usage:
  attribute :has_pet, Boolean, default: false attribute :plan, String, only: ["free", "premium"], default: "free"

🤖 Generated with [Claude Code](https://claude.com/claude-code)